### PR TITLE
Include installer fragment in NuGet package

### DIFF
--- a/Install/WiX2/Source Files/Export/RedGate.ThirdParty.LibGit2Sharp.Fork.wxs
+++ b/Install/WiX2/Source Files/Export/RedGate.ThirdParty.LibGit2Sharp.Fork.wxs
@@ -1,0 +1,29 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
+  <Fragment Id="Git2Shrp">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="git2Sharp" Guid="{8978B7F8-A28F-44DD-AB1B-67A80317C8E2}" DiskId="1">
+        <File Id="LibGit2Sharp_RedGate.dll" Name="git2srg.dll" LongName="LibGit2Sharp-RedGate.dll" DiskId="1" Source="..\Files\LibGit2Sharp-RedGate.dll" />
+        <File Id="gitlic" Name="lib2git.txt" LongName="libgit2.license.txt" DiskId="1" Source="..\Files\libgit2.license.txt" />
+      </Component>
+
+      <Directory Id="x86">
+        <Component Id="git2Sharp32" Guid="{6D93983D-2797-47A6-9486-51127D36C05F}" DiskId="1">
+          <File Id="Git2_Win32.dll" Name="git2-91f.dll" LongName="git2-91fa31f.dll" Source="..\Files\x86\git2-91fa31f.dll" />
+        </Component>
+      </Directory>
+
+      <Directory Id="x64">
+        <Component Id="git2Sharp64" Guid="{485CE328-5E75-4D7E-A583-353A0BFEE1B6}" DiskId="1" Win64="yes">
+          <File Id="Git2_Win64.dll" Name="git2-91f.dll" LongName="git2-91fa31f.dll" Source="..\Files\x64\git2-91fa31f.dll" />
+        </Component>
+      </Directory>
+    </DirectoryRef>
+
+    <!-- These get installed as part of the main product -->
+    <FeatureRef Id="Product">
+      <ComponentRef Id="git2Sharp"/>
+      <ComponentRef Id="git2Sharp32"/>
+      <ComponentRef Id="git2Sharp64"/>
+    </FeatureRef>
+  </Fragment>
+</Wix>

--- a/nuget.package/LibGit2Sharp.nuspec
+++ b/nuget.package/LibGit2Sharp.nuspec
@@ -24,5 +24,6 @@
     <file src="..\CHANGES.md" target="App_Readme\LibGit2Sharp.CHANGES.md" />
     <file src="..\nuget.package\build\*.*" target="build\net40" />
     <file src="..\Lib\NativeBinaries\libgit2.license.txt" target="App_Readme" />
+    <file src="..\Install\WiX2\Source Files\Export\RedGate.ThirdParty.LibGit2Sharp.Fork.wxs" target="wix2" />
   </files>
 </package>


### PR DESCRIPTION
This uses the same GUIDs as SOCO for the x86 and x64 components, so SOCO should be able to just remove those components from its `ToolbeltInstaller.wxs`.

I expect that I've probably got some paths wrong in the nuspec and the wxs file.
