### PR TITLE
Added a special .targets file in the nuget package build/ folder.

### DIFF
--- a/nuget.package/LibGit2Sharp-RedGate.nuspec
+++ b/nuget.package/LibGit2Sharp-RedGate.nuspec
@@ -17,15 +17,16 @@
     </references>
   </metadata>
   <files>
-    <file src="LibGit2Sharp\bin\Release\NativeBinaries\amd64\*.dll" target="lib\net35\x64" />
-    <file src="LibGit2Sharp\bin\Release\NativeBinaries\amd64\*.pdb" target="lib\net35\x64" />
-    <file src="LibGit2Sharp\bin\Release\NativeBinaries\x86\*.dll" target="lib\net35\x86" />
-    <file src="LibGit2Sharp\bin\Release\NativeBinaries\x86\*.pdb" target="lib\net35\x86" />
+    <file src="nuget.package\RedGate.ThirdParty.LibGit2Sharp.Fork.targets" target="build\net35" />
+    <file src="LibGit2Sharp\bin\Release\NativeBinaries\amd64\*.dll" target="build\net35\x64" />
+    <file src="LibGit2Sharp\bin\Release\NativeBinaries\amd64\*.pdb" target="build\net35\x64" />
+    <file src="LibGit2Sharp\bin\Release\NativeBinaries\x86\*.dll" target="build\net35\x86" />
+    <file src="LibGit2Sharp\bin\Release\NativeBinaries\x86\*.pdb" target="build\net35\x86" />
     <file src="README.md" target="App_Readme\LibGit2Sharp.README.md" />
     <file src="LICENSE.md" target="App_Readme\LibGit2Sharp.LICENSE.md" />
     <file src="CHANGES.md" target="App_Readme\LibGit2Sharp.CHANGES.md" />
     <file src="LibGit2Sharp\bin\Release\LibGit2Sharp-RedGate.dll" target="lib\net35" />
-    <file src="LibGit2Sharp\bin\Release\LibGit2Sharp-RedGate.pdb" target="lib\net35" />    
+    <file src="LibGit2Sharp\bin\Release\LibGit2Sharp-RedGate.pdb" target="lib\net35" />
     <file src="LibGit2Sharp\bin\Release\LibGit2Sharp.xml" target="lib\net35" />
     <file src="packages\LibGit2Sharp.NativeBinaries.1.0.106\libgit2\libgit2.license.txt" target="App_Readme" />
     <file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.LibGit2Sharp.Fork.wxs" target="wix2" />

--- a/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
+++ b/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
@@ -9,7 +9,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="$(MSBuildThisFileDirectory)x86\*">
-      <Link>x64\%(Filename)%(Extension)</Link>
+      <Link>x86\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
 

--- a/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
+++ b/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
@@ -1,0 +1,24 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Add the Native Binaries assemblies of the nuget package as linked items in the project file.
+    + get them to be copied to the build output folder.
+    -->
+    <None Include="$(MSBuildThisFileDirectory)x64\*.dll">
+      <Link>x64\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)x86\*.dll">
+      <Link>x64\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+
+    <!--
+    Copy the license files to the build output directory
+    -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\App_Readme\*.license.*">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
+++ b/nuget.package/RedGate.ThirdParty.LibGit2Sharp.Fork.targets
@@ -4,11 +4,11 @@
     Add the Native Binaries assemblies of the nuget package as linked items in the project file.
     + get them to be copied to the build output folder.
     -->
-    <None Include="$(MSBuildThisFileDirectory)x64\*.dll">
+    <None Include="$(MSBuildThisFileDirectory)x64\*">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="$(MSBuildThisFileDirectory)x86\*.dll">
+    <None Include="$(MSBuildThisFileDirectory)x86\*">
       <Link>x64\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
This .targets file is responsible for copying the x86/x64 native binaries
as well as the license files to the build output folder.

This means we won't have to use post build events in projects referencing
the RedGate.ThirdParty.LibGit2Sharp.Fork package
